### PR TITLE
data-drag-boundary documented, fixed sticking to boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,16 @@ dragmove(document.querySelector("#box"), document.querySelector("#box .drag-hand
 ### ES6 module
 [Check this example](https://github.com/knadh/dragmove.js/blob/master/docs/index.html) to include dragmove.js as a `<script>` directly on an HTML page.
 
+## Options
+
+Options can be set as data attributes directly on the target element:
+* **data-drag-enabled**: enable dragging - possible values: "true" (default), "false"
+* **data-drag-boundary**: limit dragging within the containing client window - possible values: "true", "false" (default)
+
+example: 
+```
+  <div id="box" data-drag-boundary="true"></div>
+```
+
+
 Licensed under the MIT License.

--- a/dragmove.js
+++ b/dragmove.js
@@ -73,12 +73,10 @@ export const dragmove = function(target, handler, onStart, onEnd) {
 
     // If boundary checking is on, don't let the element cross the viewport.
     if (target.dataset.dragBoundary === "true") {
-      if (lastX < 1 || lastX >= window.innerWidth - target.offsetWidth) {
-        return;
-      }
-      if (lastY < 1 || lastY >= window.innerHeight - target.offsetHeight) {
-        return;
-      }
+      if (lastX < 0) lastX = 0;
+      else if (lastX > window.innerWidth - target.offsetWidth) lastX = window.innerWidth - target.offsetWidth;
+      if (lastY < 0) lastY = 0;
+      else if (lastY > window.innerHeight - target.offsetHeight) lastY = window.innerHeight - target.offsetHeight;
     }
 
     target.style.left = lastX + "px";


### PR DESCRIPTION
First, one star and thank you for this lightweight utility!
While integrating it I spotted the following minor issues related to `dragBoundary`:

1. `data-drag-boundary` is not documented (neither is `data-drag-enabled`)
2. when crossing boundaries movement should not be aborted (it feels like the draggable got stuck) but instead the element should stick to the boundary
3. the default for `data-drag-boundary` should probably be true

This PR addresses the first 2 points.